### PR TITLE
Fix MD5 TCP signature with new FreeBSD tcpmd5 kernel module

### DIFF
--- a/sysdep/bsd/setkey.h
+++ b/sysdep/bsd/setkey.h
@@ -160,12 +160,14 @@ sk_set_md5_in_sasp_db(sock *s, ip_addr local, ip_addr remote, struct iface *ifa,
     if (len > TCP_KEYLEN_MAX)
       ERR_MSG("The password for TCP MD5 Signature is too long");
 
-    if (setkey_md5(&src, &dst, pxlen, passwd, SADB_ADD) < 0)
+    if (setkey_md5(&src, &dst, pxlen, passwd, SADB_ADD) < 0 ||
+        setkey_md5(&dst, &src, pxlen, passwd, SADB_ADD) < 0)
       ERR_MSG("Cannot add TCP-MD5 password into the IPsec SA/SP database");
   }
   else
   {
-    if (setkey_md5(&src, &dst, pxlen, NULL, SADB_DELETE) < 0)
+    if (setkey_md5(&src, &dst, pxlen, NULL, SADB_DELETE) < 0 ||
+        setkey_md5(&dst, &src, pxlen, NULL, SADB_DELETE) < 0)
       ERR_MSG("Cannot delete TCP-MD5 password from the IPsec SA/SP database");
   }
   return 0;


### PR DESCRIPTION
A new tcpmd5 kernel module was introduced into FreeBSD 11.1 and userland code needs to be adapted. Cf FreeBSD's Problem Report #218907 (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=218907) for more information.